### PR TITLE
Invalid Usernames

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,4 +26,4 @@ en:
         user:
           attributes:
             username:
-              invalid: "must be at least 3 characters long with no spaces: bob, بوب, 鲍_勃"
+              invalid: "must be 3 or more characters with no spaces or special characters other than underscore: bob, بوب, 鲍_勃"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,4 +26,4 @@ en:
         user:
           attributes:
             username:
-              invalid: "must be at least 3 characters long: bob, بوب, 鲍_勃"
+              invalid: "must be at least 3 characters long with no spaces: bob, بوب, 鲍_勃"


### PR DESCRIPTION
**Problem:** The validation message on usernames didn't specify not to use spaces. More generally, the validation message was incorrect.

**Solution:** Include a note about not allowing spaces. Closes #1 

**Complications:** This doesn't exactly solve the more general problem, since I'm not 100% sure what the username regex will and won't match, but in this case, at least. it will have solved the problem.

**Feature Changelog:**

- Username validation now says you cannot have spaces
