### PR TITLE
Transactional emails via Postmarkapp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'acts_as_votable', '~> 0.10.0'
 gem 'bootstrap-sass', '~> 3.3.6'
 gem 'autoprefixer-rails', '~> 6.4.0.1'
 gem 'closure_tree', '~> 6.1.0'
+gem 'postmark-rails', '~> 0.14.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 5.0.0', '< 5.1'
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -103,6 +104,12 @@ GEM
     orm_adapter (0.5.0)
     pg (0.18.4)
     pkg-config (1.1.7)
+    postmark (1.9.1)
+      json
+      rake
+    postmark-rails (0.14.0)
+      actionmailer (>= 3.0.0)
+      postmark (~> 1.9.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -198,6 +205,7 @@ DEPENDENCIES
   jquery-rails (~> 4.1.1)
   listen (~> 3.0.5)
   pg (~> 0.18)
+  postmark-rails (~> 0.14.0)
   pry-rails
   puma (~> 3.0)
   rails (>= 5.0.0, < 5.1)

--- a/app.json
+++ b/app.json
@@ -30,6 +30,9 @@
     },
     "POSTMARK_API_TOKEN": {
       "required": true
+    },
+    "IS_REVIEW_APP": {
+      "required": true
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -27,6 +27,9 @@
     },
     "GITTER_WEBHOOK_URL": {
       "required": true
+    },
+    "POSTMARK_API_TOKEN": {
+      "required": true
     }
   },
   "formation": {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   # Virtual attribute for authenticating by either username or email
   # This is in addition to a real persisted field like 'username'

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
 <p>Welcome to Project Credo!</p>
 
-<p>This email has been signed up for our website.  You can confirm your account email through the link below:</p>
+<p>This email has been signed up for our website.  You can confirm your account email by clicking this link:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<p>Or by copying and pasting the URL below:</p>
+
+<p><%= link_to confirmation_url(@resource, confirmation_token: @token), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,11 +26,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
@@ -58,4 +53,9 @@ Rails.application.configure do
   end
 
   config.web_console.automount = true
+
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.default charset: "utf-8"
+  config.action_mailer.raise_delivery_errors = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,8 +54,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  config.action_mailer.default_url_options = { host: 'REPLACEME', port: 3000 }
-
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "projectcredo_#{Rails.env}"
@@ -87,4 +85,11 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.action_mailer.default charset: "utf-8"
+  config.action_mailer.delivery_method = :postmark
+  config.action_mailer.postmark_settings = { api_token: ENV['POSTMARK_API_TOKEN'] }
+  config.action_mailer.default_url_options = { host: 'projectcredo.com' }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,11 @@ Rails.application.configure do
   config.action_mailer.default charset: "utf-8"
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = { api_token: ENV['POSTMARK_API_TOKEN'] }
-  config.action_mailer.default_url_options = { host: 'projectcredo.com' }
+  if ENV['IS_REVIEW_APP']
+    config.action_mailer.default_url_options = { host: "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" }
+  else
+    config.action_mailer.default_url_options = { host: 'projectcredo.com' }
+  end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,7 +3,7 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
+      confirmed: "Your email address has been successfully confirmed and you can now sign in."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:


### PR DESCRIPTION
**Problem:** Emails were not being sent

**Solution:** Use Postmark App for transactional emails.

**Complications:** We may (eventually) run up their 25,000 test email budget. That would be a good thing.

**Feature Changelog:**

- Emails for sign up, forgotten password, etc. are now sent
