### PR TITLE
API Import (and Response) fix

### DIFF
--- a/app/models/api_import_response.rb
+++ b/app/models/api_import_response.rb
@@ -7,7 +7,7 @@ class ApiImportResponse < ApplicationRecord
     if xml
       Nokogiri::XML(xml, &:noblanks)
     elsif json
-      JSON.parse(json)
+      json
     end
   end
 end

--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -29,6 +29,7 @@ class Crossref
       {
         import_source:      lambda {|data| 'crossref' },
         title:              lambda {|data| data.dig 'message', 'title', 0 },
+        abstract:           lambda {|data| data.dig 'message', 'abstract' },
         publication:        lambda {|data| data.dig 'message', 'short-container-title', 0 },
         doi:                lambda {|data| self.id },
         pubmed_id:          lambda {|data| Pubmed.get_uid_from_doi(id) },


### PR DESCRIPTION
**Problems:**

1. The API Import Response `#body` method was breaking because it was trying to parse JSON stored in the db. Since pg supports JSON natively, it was already parsed into a Ruby hash.
2. The abstracts in Crossref weren't being imported.

**Solution:**

1. Undo parsing the json
2. Import the abstract

**Complications:**

**Feature Changelog:**

- Abstracts should now be imported from Crossref.
- `ApiImportResponse` should be able to use the `#body` method 
