### PR TITLE
Uses correct path

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,4 +86,9 @@ class User < ApplicationRecord
   def to_param
     username
   end
+
+  protected
+    def confirmation_required?
+      false
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :confirmable
+         :recoverable, :rememberable, :trackable, :validatable
 
   # Virtual attribute for authenticating by either username or email
   # This is in addition to a real persisted field like 'username'

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -39,9 +39,3 @@
     <%= f.submit "Update", class: "btn btn-primary" %>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_user_confirmation_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -180,11 +180,6 @@ ActiveRecord::Schema.define(version: 20161121173053) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "username"
-    t.string   "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
     t.index ["username"], name: "index_users_on_username", unique: true, using: :btree


### PR DESCRIPTION
**Problem:** Post-sign in would break

**Solution:** Use correct path

**Complications:**

**Feature Changelog:**

- [bug] Site no longer breaks after log in
- Mitigates schema mismatch by deleting schema attrs and not requiring email confirmation
- Removes account cancellation button to mitigate #8 
