### PR TITLE
Pubmed abstract for crossref

### DIFF
--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -29,7 +29,17 @@ class Crossref
       {
         import_source:      lambda {|data| 'crossref' },
         title:              lambda {|data| data.dig 'message', 'title', 0 },
-        abstract:           lambda {|data| data.dig 'message', 'abstract' },
+        abstract:           lambda do |data|
+          if (abstract = data.dig 'message', 'abstract')
+          elsif (uid = Pubmed.get_uid_from_doi(id))
+            pubmed = Pubmed.new locator_id: uid
+            abstract = pubmed.resource.paper_attributes[:abstract]
+          else
+            abstract = nil
+          end
+
+          return abstract
+        end,
         publication:        lambda {|data| data.dig 'message', 'short-container-title', 0 },
         doi:                lambda {|data| self.id },
         pubmed_id:          lambda {|data| Pubmed.get_uid_from_doi(id) },

--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -31,12 +31,12 @@ class Crossref
         import_source:      lambda {|data| 'crossref' },
         title:              lambda {|data| data.dig 'message', 'title', 0 },
         abstract:           lambda do |data|
-          if (abstract = data.dig 'message', 'abstract')
-          elsif (uid = Pubmed.get_uid_from_doi(id))
+          abstract = data.dig 'message', 'abstract'
+          
+          if abstract.nil?
+            uid = Pubmed.get_uid_from_doi(id)
             pubmed = Pubmed.new locator_id: uid
             abstract = pubmed.resource.paper_attributes[:abstract]
-          else
-            abstract = nil
           end
 
           return abstract

--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -11,6 +11,7 @@ class Crossref
         begin
           data = JSON.parse response.body
           @paper_attributes ||= map_attributes(mapper, data)
+          @paper_attributes[:abstract_editable] = @paper_attributes[:abstract].nil?
         rescue JSON::ParserError => e
           logger.debug "Malformed JSON response: \"#{e.message}\" for #{response.body}"
         end


### PR DESCRIPTION
Problem:
Crossref had papers with no abstracts that were available via Pubmed
Solution:
Pull pubmed data when available
Complications:
We should discuss a long term technical solution for mixing data. I don't fully understand the architecture and how it will play out for our purposes in the long run.

Feature Changelog:

-grab abstract from pubmed
-mark abstract as not editable if it was imported from crossref or pubmed