### PR TITLE
Force ssl env

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,31 +8,30 @@ class ApplicationController < ActionController::Base
   force_ssl if: ->{ Rails.env.production? }, except: :lets_encrypt
 
   protected
+    def configure_permitted_parameters
+      added_attrs = [:username, :email, :password, :password_confirmation, :remember_me]
+      devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+      devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+    end
 
-  def configure_permitted_parameters
-    added_attrs = [:username, :email, :password, :password_confirmation, :remember_me]
-    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
-    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
-  end
+    def store_pre_signin_path
+      return if !request.get? || request.xhr?
 
-  def store_pre_signin_path
-    return if !request.get? || request.xhr?
+      user_paths = [
+        "/users/sign_in",
+        "/users/sign_up",
+        "/users/password/new",
+        "/users/password/edit",
+        "/users/confirmation",
+        "/users/sign_out"
+      ]
 
-    user_paths = [
-      "/users/sign_in",
-      "/users/sign_up",
-      "/users/password/new",
-      "/users/password/edit",
-      "/users/confirmation",
-      "/users/sign_out"
-    ]
+      store_location_for(:user, request.fullpath) unless user_paths.include?(request.path)
+    end
 
-    store_location_for(:user, request.fullpath) unless user_paths.include?(request.path)
-  end
-
-  def ajax_redirect_to(redirect_uri)
-    render js: "window.location.replace('#{redirect_uri}');"
-  end
+    def ajax_redirect_to(redirect_uri)
+      render js: "window.location.replace('#{redirect_uri}');"
+    end
 
   private
     def ensure_current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   after_filter :store_pre_signin_path
 
+  force_ssl if: ->{ Rails.env.production? }, except: :lets_encrypt
+
   protected
 
   def configure_permitted_parameters

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_cable.mount_path = nil
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
**Problem:**

I tried to get certificates for www.projectcredo.com and projectcredo.com (@ in DNS records), but I ended up figuring out that a) the single LetsEncrypt endpoint needs to be unencrypted (http), and b) that I may have found a way to get both www and @ addresses to be secured. We'll see when the DNS settings take hold in ~24 hours.

**Solution:** Force SSL only in production, except on the LetsEncrypt endpoint.
