### PR TITLE
Fixes email host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,7 +92,7 @@ Rails.application.configure do
   if ENV['IS_REVIEW_APP']
     config.action_mailer.default_url_options = { host: "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" }
   else
-    config.action_mailer.default_url_options = { host: 'projectcredo.com' }
+    config.action_mailer.default_url_options = { host: 'www.projectcredo.com' }
   end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
**Problem:** The reset password email didn't work.

**Solution:** The ActionMailer hostname was wrong, so just set it to the www address. Unfortunately, all links without www will simply go back to the homepage.

**Complications:**

**Feature Changelog:**

- [bug] Fix links in emails

