### PR TITLE
Adds explicit url for copying/pasting purposes

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -4,5 +4,9 @@
 
 <p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
+<p>Or by copying and pasting this link into your browser URL bar:</p>
+
+<p><%= edit_password_url(@resource, reset_password_token: @token) %></p>
+
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,9 +90,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = { api_token: ENV['POSTMARK_API_TOKEN'] }
   if ENV['IS_REVIEW_APP']
-    config.action_mailer.default_url_options = { host: "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" }
+    config.action_mailer.default_url_options = { host: "#{ENV['HEROKU_APP_NAME']}.herokuapp.com", protocol: :https }
   else
-    config.action_mailer.default_url_options = { host: 'www.projectcredo.com' }
+    config.action_mailer.default_url_options = { host: 'www.projectcredo.com', protocol: :https }
   end
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Having a plaintext URL to copy and paste can be handy.

**Feature Changelog:**

- Adds a plaintext URL to password reset emails.
- Forces HTTPS on links in emails in production