### PR TITLE
Makes username login case insensitive

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,7 +78,7 @@ class User < ApplicationRecord
   def self.find_for_database_authentication(warden_conditions)
     conditions = warden_conditions.dup
     if login = conditions.delete(:login)
-      return where(conditions.to_h).where(["username = :value OR lower(email) = :value", { :value => login.downcase }]).first
+      return where(conditions.to_h).where(["lower(username) = :value OR lower(email) = :value", {value: login.downcase}]).first
     end
     super(conditions)
   end


### PR DESCRIPTION
**Problem:** Usernames are case sensitive on login

**Solution:** Change login method to search usernames in a case insensitive manner

**Complications:**

**Feature Changelog:**

- [bug] Fixes case sensitive login issues
