### PR TITLE
Uses the full width of the page to display lists

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,3 +1,3 @@
-.cards > div:nth-child(3n+1) {
+.cards > div:nth-child(4n+1) {
   clear: left;
 }

--- a/app/assets/stylesheets/_navbar.scss
+++ b/app/assets/stylesheets/_navbar.scss
@@ -28,12 +28,3 @@
     border-bottom-right-radius: 4px;
   }
 }
-
-@media(min-width:768px) {
-  .container-fluid {
-    display: flex;
-  }
-  .navbar-header {
-    flex: 1;
-  }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,10 +27,7 @@
 @import "about";
 
 body {
-  line-height: 1.5;
   padding: 4em 1em;
-  margin: 0 auto;
-  max-width: 70em;
   font-family: "Helvetica", "Arial", sans-serif;
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
       <%= content_tag(:p, notice, class: "notice alert-success") if notice %>
       <%= content_tag(:p, alert, class: "alert alert-danger") if alert %>
     </div>
-    <div class="container-fluid">
+    <div class="container<%= '-fluid' if @full_width %>">
       <%= yield %>
     </div>
     <%= console if Rails.env.development? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,9 @@
       <%= content_tag(:p, notice, class: "notice alert-success") if notice %>
       <%= content_tag(:p, alert, class: "alert alert-danger") if alert %>
     </div>
-    <%= yield %>
+    <div class="container-fluid">
+      <%= yield %>
+    </div>
     <%= console if Rails.env.development? %>
   </body>
 </html>

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -20,14 +20,13 @@
                           class: "form-control hidden paper-title input-sm",
                           disabled: true %>
         <div class="form-group">
-        <%= f.submit "Submit",
-              class: "btn btn-primary btn-xs hidden",
-              id: 'add_locator_submit',
-              disabled: !(list.accepts_public_contributions? || current_user_can_edit?(list)) %>
-        <%= link_to "cancel", '#', id: "cancel-add-locator", class: "hidden" %>
+          <%= f.submit "Submit",
+                class: "btn btn-primary btn-xs hidden",
+                id: 'add_locator_submit',
+                disabled: !(list.accepts_public_contributions? || current_user_can_edit?(list)) %>
+          <%= link_to "cancel", '#', id: "cancel-add-locator", class: "hidden" %>
         </div>
       </div>
     <% end %>
-    </div>
   </div>
 <% end %>

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-4 list-card">
+<div class="col-md-3 list-card">
   <div class="panel panel-default">
     <div class="panel-body">
       <% if user_signed_in? %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,4 +1,7 @@
-<% @title = 'Home' %>
+<%
+  @title = 'Home'
+  @full_width = true
+%>
 
 <% if @pinned_lists.present? %>
   <div class="row">

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -1,9 +1,9 @@
 <% @title = 'Home' %>
 
 <% if @pinned_lists.present? %>
-  <h1>Pinned Lists</h1>
   <div class="row">
     <div class="col-md-12">
+      <h1>Pinned Lists</h1>
       <%= link_to 'Create New List', new_list_path %>
     </div>
   </div>
@@ -14,9 +14,9 @@
 <% end %>
 
 <% if @unpinned_lists.present? %>
-  <h1>Lists</h1>
   <div class="row">
     <div class="col-md-12">
+      <h1>Lists</h1>
       <%= link_to 'Create New List', new_list_path %>
     </div>
   </div>

--- a/app/views/users/lists/index.html.erb
+++ b/app/views/users/lists/index.html.erb
@@ -1,4 +1,7 @@
-<% @title = "#{@user.username}'s lists" %>
+<%
+  @title = "#{@user.username}'s lists"
+  @full_width = true
+%>
 
 <h1>
   <span><%= "#{@user.username}'s" %> Lists</span>

--- a/app/views/users/lists/show.html.erb
+++ b/app/views/users/lists/show.html.erb
@@ -34,5 +34,3 @@
   <i><%= reference_count%> papers added to this list</i>
 <% end %>
 <%= render partial: 'references/reference', collection: @references, locals: {show_comments: false} %>
-
-


### PR DESCRIPTION
**Problem:** The viewable area was too small for cards

**Solution:** Make the viewable area take up the full width of the screen

**Complications:** Non-list#index views can look a little bit wonky

**Feature Changelog:**

- Page now takes up the full width of the screen on list index pages
