### PR TITLE
Relaxes DOI regexp

### DIFF
--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -4,7 +4,7 @@ class Crossref
 
     def initialize id
       self.id = id.to_s
-      endpoint = URI.parse("https://api.crossref.org/works/#{self.id}")
+      endpoint = URI.parse("https://api.crossref.org/works/#{CGI.escape self.id}")
       self.response = Net::HTTP.get_response endpoint
 
       if response.code_type.ancestors.include?(Net::HTTPSuccess)

--- a/app/models/services/locators/doi_paper_locator.rb
+++ b/app/models/services/locators/doi_paper_locator.rb
@@ -28,7 +28,7 @@ class DoiPaperLocator
 
   def valid?
     # Stolen from http://blog.crossref.org/2015/08/doi-regular-expressions.html
-    is_doi = locator_id.match(/^10.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i)
+    is_doi = locator_id.match(/^10.\d{4,9}\/[^\s]+$/)
 
     errors << "\"#{locator_id}\" does not match DOI format. Ex: \"10.1371/journal.pone.0001897\"" unless is_doi
 


### PR DESCRIPTION
**Problem:** DOIs from hell, like `10.1175/1520-0469(1967)024<0241:teotaw>2.0.co;2` break the validators because obviously

**Solution:** Relax the DOI regex to allow insane DOIs

**Complications:** It also broke the URI parser that we use to fetch the Crossref Resource, so I escaped it in the string interpolation, as well.

**Feature Changelog:**

- [bug] Allow insane DOIs like `10.1175/1520-0469(1967)024<0241:teotaw>2.0.co;2`

