### PR TITLE
Autolink

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 module ApplicationHelper
   def wrap_on_line_breaks text
-    text.to_s.split(/(?:\n\r?|\r\n?)/).map {|s| "<p>#{h s}</p>"}.join.html_safe
+    text.to_s.split(/(?:\n\r?|\r\n?)/).map {|s| autolink "<p>#{h s}</p>"}.join.html_safe
+  end
+
+  def autolink text
+    text.gsub(URI::regexp(%w(http https))) {|match| link_to match, match}
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,9 @@ module ApplicationHelper
   end
 
   def autolink text
-    text.gsub(URI::regexp(%w(http https))) {|match| link_to match, match}
+    text.gsub(URI::regexp(%w(http https))) do |match|
+      unescaped_url = CGI.unescapeHTML match
+      link_to unescaped_url, unescaped_url
+    end
   end
 end


### PR DESCRIPTION
**Problem:** URLs in list descriptions and comments weren't treated as links

**Solution:** Find them and make them links

**Complications:** I unescaped the URL, but I don't know if this will have repercussions down the line - what other entities are unescaped that should not be.

**Feature Changelog:**

- URLs in user submitted text now linked.
