### PR TITLE
fix link removal

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -16,7 +16,7 @@ class LinksController < ApplicationController
               notice: "'#{link.url}' has been successfully removed from '#{link.paper.title}'"
             )
         end
-        format.js { render('destroy.js.erb', locals: { reference_id: reference.id }) }
+        format.js { render('destroy.js.erb') }
       else
         flash[:alert] = 'You do not have permission to moderate this list.'
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2,22 +2,21 @@ class LinksController < ApplicationController
   before_action :ensure_current_user
 
   def destroy
-    link = Link.find(link_params[:id])
-    url = link.url
+    @link = Link.find(link_params[:id])
     reference = Reference.find(params[:reference])
     list = reference.list
 
     respond_to do |format|
       list_path = user_list_path(list.owner, list)
       if current_user.can_moderate?(list)
-        link.destroy
+        @link.destroy
         format.html do
             redirect_back(
               fallback_location: list_path,
               notice: "'#{link.url}' has been successfully removed from '#{link.paper.title}'"
             )
         end
-        format.js { render('destroy.js.erb', locals: { url: url, reference_id: reference.id }) }
+        format.js { render('destroy.js.erb', locals: { reference_id: reference.id }) }
       else
         flash[:alert] = 'You do not have permission to moderate this list.'
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -13,7 +13,7 @@ class LinksController < ApplicationController
         format.html do
             redirect_back(
               fallback_location: list_path,
-              notice: "'#{link.url}' has been successfully removed from '#{link.paper.title}'"
+              notice: "'#{@link.url}' has been successfully removed from '#{@link.paper.title}'"
             )
         end
         format.js { render('destroy.js.erb') }

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -3,12 +3,12 @@ class LinksController < ApplicationController
 
   def destroy
     link = Link.find(link_params[:id])
+    url = link.url
     reference = Reference.find(params[:reference])
     list = reference.list
 
     respond_to do |format|
       list_path = user_list_path(list.owner, list)
-
       if current_user.can_moderate?(list)
         link.destroy
         format.html do
@@ -17,7 +17,7 @@ class LinksController < ApplicationController
               notice: "'#{link.url}' has been successfully removed from '#{link.paper.title}'"
             )
         end
-        format.js { render('destroy.js.erb', reference: reference) }
+        format.js { render('destroy.js.erb', locals: { url: url, reference_id: reference.id }) }
       else
         flash[:alert] = 'You do not have permission to moderate this list.'
 

--- a/app/views/links/_links.html.erb
+++ b/app/views/links/_links.html.erb
@@ -10,7 +10,7 @@
 
 <% if paper.links.any? %>
   <% paper.links.each do |l| %>
-    <li>
+    <li id="link-<%= l.id %>">
       <%= link_to l.url, l.url, target: '_blank' %>
       <% if l.link_editable && current_user_can_moderate?(reference.list) %>
         <%= link_to '',

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,3 +1,3 @@
 $("#link-<%= @link.id %>").remove();
 
-<%= render 'layouts/flash_messages', flash: {notice: '#{@link.url}' has been successfully removed from '#{@link.paper.title}'} %>
+<%= render 'layouts/flash_messages', flash: {alert: "#{@link.url} has been successfully removed from #{@link.paper.title}"} %>

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,3 +1,3 @@
 $("#link-<%= @link.id %>").remove();
 
-<%= render 'layouts/flash_messages', flash: {alert: "#{@link.url} has been successfully removed from #{@link.paper.title}"} %>
+<%= render 'layouts/flash_messages', flash: {notice: "#{@link.url} has been successfully removed from #{@link.paper.title}"} %>

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,4 +1,4 @@
-url = "<%= url %>"
-link = $("#details-<%= reference_id %>").find("a[href= '" + url + "']");
-linkLi = link.parent('li');
-linkLi.remove();
+link = $("#link-<%= @link.id %>")
+link.remove();
+
+<%= render 'layouts/flash_messages', flash: {notice: 'Link deleted.'} %>

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,3 +1,3 @@
 $("#link-<%= @link.id %>").remove();
 
-<%= render 'layouts/flash_messages', flash: {notice: 'Link deleted.'} %>
+<%= render 'layouts/flash_messages', flash: {notice: '#{@link.url}' has been successfully removed from '#{@link.paper.title}'} %>

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,4 +1,3 @@
-link = $("#link-<%= @link.id %>")
-link.remove();
+$("#link-<%= @link.id %>").remove();
 
 <%= render 'layouts/flash_messages', flash: {notice: 'Link deleted.'} %>

--- a/app/views/links/destroy.js.erb
+++ b/app/views/links/destroy.js.erb
@@ -1,6 +1,4 @@
-linksList = "<%= escape_javascript(render('links/links', reference: reference)) %>";
-linksUL = $("#details-<%= reference.id %>").find('.links');
-
-linksUL.html(linksList);
-
-
+url = "<%= url %>"
+link = $("#details-<%= reference_id %>").find("a[href= '" + url + "']");
+linkLi = link.parent('li');
+linkLi.remove();


### PR DESCRIPTION
**Problem:**
Links weren't being removed on click
**Solution:**
instead of refreshing links/links, just find the 'li' with the link and remove it.
**Complications:**
I'm not sure why the method we had before wasn't working.  Something we changed since then must have been screwy.  We probably also had to send in the current user.  this is cleaner so should be ok.

