### PR TITLE
Fix update comment ujs

### DIFF
--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,4 +1,4 @@
 commentContent = $("#comment-<%= @comment.id %> > .content")
-commentContent.html("<%= wrap_on_line_breaks @comment.content %>")
+commentContent.html("<%= escape_javascript wrap_on_line_breaks(@comment.content) %>")
 editLink = $("#comment-<%= @comment.id %>").find("a.edit-comment").first()
 editLink.parent('li').toggleClass('hidden', false);


### PR DESCRIPTION
**Problem:** When updating a comment with a URL in it, the edit form would refuse to go away.

**Solution:** Escape the comment and the URL so ending quotes no longer break javascript

**Feature Changelog:**

- [bug] Updating comments now works without refresh

