### PR TITLE
Deactive deleted user's comments

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,32 +1,28 @@
-<% if comment.user %>
-  <div class="comment" id="comment-<%= comment.id %>" >
-    <p class="text-muted">
-      <%= if comment.created_at == comment.updated_at then 'Added by' else 'Updated by' end %>
-      <strong><%= link_to comment.user.username, user_lists_path(comment.user.username) %></strong> on <%= l(comment.updated_at, format: '%B, %d %Y %H:%M:%S') %>
-    </p>
-    <% comment_content = wrap_on_line_breaks comment.content %>
-    <%= content_tag(:span, comment_content, class: "content") %>
-    <ul>
-      <li><%= render 'votes/toggle_like', votable: comment %></li>
-      <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
-      <% if current_user == comment.user %>
-        <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
-        <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
-      <% elsif current_user_can_moderate?(list) %>
-        <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
+<div class="comment" id="comment-<%= comment.id %>" >
+  <p class="text-muted">
+    <%= if comment.created_at == comment.updated_at then 'Added by' else 'Updated by' end %>
+    <strong>
+      <% if comment.user %>
+        <%= link_to comment.user.username, user_lists_path(comment.user.username) %>
+      <% else %>
+        [deleted]
       <% end %>
-    </ul>
-    <%= render('comments/form', comment: comment.children.build, hidden: true) if current_user %>
+    </strong>
+    on <%= l(comment.updated_at, format: '%B, %d %Y %H:%M:%S') %>
+  </p>
+  <% comment_content = wrap_on_line_breaks comment.content %>
+  <%= content_tag(:span, comment_content, class: "content") %>
+  <ul>
+    <li><%= render 'votes/toggle_like', votable: comment %></li>
+    <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
+    <% if current_user == comment.user %>
+      <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
+      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
+    <% elsif current_user_can_moderate?(list) %>
+      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
+    <% end %>
+  </ul>
+  <%= render('comments/form', comment: comment.children.build, hidden: true) if current_user %>
 
-    <%= yield %>
-  </div>
-<% else %>
-  <div class="comment">
-    <p class="text-muted">
-      The user who added this comment is no longer available
-    </p>
-    <span class="content">
-      This comment is no longer available
-    </span>
-  </div>
-<% end %>
+  <%= yield %>
+</div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,21 +1,32 @@
-<div class="comment" id="comment-<%= comment.id %>" >
-  <p class="text-muted">
-    <%= if comment.created_at == comment.updated_at then 'Added by' else 'Updated by' end %>
-    <strong><%= link_to comment.user.username, user_lists_path(comment.user.username) %></strong> on <%= l(comment.updated_at, format: '%B, %d %Y %H:%M:%S') %>
-  </p>
-  <% comment_content = wrap_on_line_breaks comment.content %>
-  <%= content_tag(:span, comment_content, class: "content") %>
-  <ul>
-    <li><%= render 'votes/toggle_like', votable: comment %></li>
-    <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
-    <% if current_user == comment.user %>
-      <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
-      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
-    <% elsif current_user_can_moderate?(list) %>
-      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
-    <% end %>
-  </ul>
-  <%= render('comments/form', comment: comment.children.build, hidden: true) if current_user %>
+<% if comment.user %>
+  <div class="comment" id="comment-<%= comment.id %>" >
+    <p class="text-muted">
+      <%= if comment.created_at == comment.updated_at then 'Added by' else 'Updated by' end %>
+      <strong><%= link_to comment.user.username, user_lists_path(comment.user.username) %></strong> on <%= l(comment.updated_at, format: '%B, %d %Y %H:%M:%S') %>
+    </p>
+    <% comment_content = wrap_on_line_breaks comment.content %>
+    <%= content_tag(:span, comment_content, class: "content") %>
+    <ul>
+      <li><%= render 'votes/toggle_like', votable: comment %></li>
+      <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
+      <% if current_user == comment.user %>
+        <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
+        <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
+      <% elsif current_user_can_moderate?(list) %>
+        <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
+      <% end %>
+    </ul>
+    <%= render('comments/form', comment: comment.children.build, hidden: true) if current_user %>
 
-  <%= yield %>
-</div>
+    <%= yield %>
+  </div>
+<% else %>
+  <div class="comment">
+    <p class="text-muted">
+      The user who added this comment is no longer available
+    </p>
+    <span class="content">
+      This comment is no longer available
+    </span>
+  </div>
+<% end %>


### PR DESCRIPTION
**Note:** Submitting this for initial review before continuing to work on the remaining bugs listed in #8 

**Problem:**
Deleted user's comments were causing a null-pointer exception

**Solution:**
Only display a comment if it has an active userId; display error message otherwise. 

**Complications:**
N/A

**Feature Changelog:**
Resolves the first part of #8 

- Add check on user attribute of each comment before rendering 