### PR TITLE
Makes docker optional

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -19,9 +19,11 @@ default: &default
   encoding: unicode
   pool: 5
   timeout: 5000
+<% if ENV['DOCKERIZED'] ==  'true' %>
   username: postgres
   host: postgres
   port: 5432
+<% end %>
 
 development:
   <<: *default


### PR DESCRIPTION
**Problem:** Docker not being optional has screwed up a lot of things, the last of which was Travis CI. Also, very few people are familiar with Docker, so perhaps having this option will be helpful.

**Solution:** Make docker optional.

**Additional Notes:** If you want to use Rails without Docker, you can now do so, though you will need to setup postgresql and associated users with permissions as well.
