### PR TITLE
Vueifies Add Reference

### DIFF
--- a/app/assets/javascripts/references.js
+++ b/app/assets/javascripts/references.js
@@ -41,49 +41,4 @@ $(document).ready(function() {
     tagsList.toggleClass('hidden', false);
     tagsForm.toggleClass('hidden', true);
   });
-
-  paperType = $('#add_locator_type');
-  paperLocator = $('#reference_locator_id');
-  paperTitle = $('#reference_locator_title');
-  paperSubmit = $('#add_locator_submit');
-  cancelAddLocator = $('#cancel-add-locator');
-
-  $('.add-paper a#add-doi').on('click', function() {
-    paperLocator.toggleClass('hidden', false).attr("placeholder", "DOI ex: '10.1371/journal.pone.0001897'");
-    paperType.val('doi');
-    paperSubmit.toggleClass('hidden', false);
-    cancelAddLocator.toggleClass('hidden', false);
-    if (paperLocator.prop('disabled')) { paperLocator.prop('disabled', false); };
-    paperTitle.toggleClass('hidden', true)
-    if (!paperTitle.prop('disabled')) { paperTitle.prop('disabled', true); };
-  });
-
-  $('.add-paper a#add-pubmed').on('click', function() {
-    paperLocator.toggleClass('hidden', false).attr("placeholder", "Pubmed ID ex: '18365029'");
-    paperType.val('pubmed');
-    paperSubmit.toggleClass('hidden', false);
-    cancelAddLocator.toggleClass('hidden', false);
-    if (paperLocator.prop('disabled')) { paperLocator.prop('disabled', false); };
-    paperTitle.toggleClass('hidden', true)
-    if (!paperTitle.prop('disabled')) { paperTitle.prop('disabled', true); };
-  });
-
-  $('.add-paper a#add-link').on('click', function() {
-    paperLocator.toggleClass('hidden', false).attr("placeholder", "URL ex: http://journals.plos.org/plosone/article?id=example");
-    paperType.val('link');
-    paperSubmit.toggleClass('hidden', false);
-    cancelAddLocator.toggleClass('hidden', false);
-    if (paperLocator.prop('disabled')) { paperLocator.prop('disabled', false); };
-    paperTitle.toggleClass('hidden', false)
-    if (paperTitle.prop('disabled')) { paperTitle.prop('disabled', false); };
-  });
-
-  cancelAddLocator.on('click', function() {
-    paperLocator.toggleClass('hidden', true).prop('disabled', true).val('');
-    paperType.val('');
-    paperSubmit.toggleClass('hidden', true);
-    cancelAddLocator.toggleClass('hidden', true);
-    paperTitle.toggleClass('hidden', true).val('');
-    if (!paperTitle.prop('disabled')) { paperTitle.prop('disabled', true); };
-  });
 });

--- a/app/assets/stylesheets/_reference.scss
+++ b/app/assets/stylesheets/_reference.scss
@@ -2,11 +2,11 @@
   padding: 0;
 
   .paper-locator {
-    width: 25%;
+    width: 15em;
   }
 
   .paper-title {
-    width: 35%;
+    width: 25em;
   }
 }
 

--- a/app/assets/stylesheets/_reference.scss
+++ b/app/assets/stylesheets/_reference.scss
@@ -8,7 +8,6 @@
   .paper-title {
     width: 35%;
   }
-
 }
 
 .reference-detail {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,7 +39,7 @@ body {
 }
 
 input[placeholder] {
-    text-overflow: ellipsis;
+  text-overflow: ellipsis;
 }
 
 .remove-button {
@@ -51,8 +51,8 @@ input[placeholder] {
 }
 
 .remove-button:hover {
-    background: none;
-    text-decoration: none;
+  background: none;
+  text-decoration: none;
 }
 
 .flash-messages {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
     <div class="container<%= '-fluid' if @full_width %>">
       <%= yield %>
     </div>
-    <%# console if Rails.env.development? %>
+    <%= console if Rails.env.development? && ENV['CONSOLE_ENABLED'] %>
   </body>
   <%= yield(:page_app) %>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,4 +58,5 @@
     </div>
     <%= console if Rails.env.development? %>
   </body>
+  <%= yield(:page_app) %>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,7 +56,7 @@
     <div class="container<%= '-fluid' if @full_width %>">
       <%= yield %>
     </div>
-    <%= console if Rails.env.development? %>
+    <%# console if Rails.env.development? %>
   </body>
   <%= yield(:page_app) %>
 </html>

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -1,44 +1,73 @@
-<%= form_for list.references.build, html: {class: 'form-inline'} do |f| %>
+<%= form_for list.references.build, html: {class: 'form-inline', id: 'add-reference'} do |f| %>
   <%= f.hidden_field :list_id, value: list.id %>
   <div class="add-paper">
     <%= f.fields_for :locator do |l| %>
       <div class="form-group add-reference col-md-12">
-        <%= l.hidden_field :type, value: '', id: 'add_locator_type' %>
+        <%= l.hidden_field :type, 'v-bind:value' => 'locatorType' %>
         <i>
           Or add a paper by
-          <%= link_to "DOI", '#', id: "add-doi" %>,
-          <%= link_to "Pubmed ID", '#', id: "add-pubmed" %>,
-          or <%= link_to "URL", '#', id: "add-link" %>
+          <%= link_to "DOI", '', '@click.prevent': "addDoi" %>,
+          <%= link_to "Pubmed ID", '', '@click.prevent': "addPubmed" %>,
+          or <%= link_to "URL", '', '@click.prevent': "addUrl" %>
         </i>
-        <%= l.text_field  :id,
-                          placeholder: 'URL, DOI, or Pubmed',
-                          class: "form-control hidden paper-locator input-sm",
-                          disabled: true %>
+        <div class="form-group" v-bind:class='{ hidden: dataHidden }'>
+          <%= l.text_field  :id,
+                            class: "form-control paper-locator input-sm",
+                            'v-bind:placeholder' => 'locatorIdPlaceholder',
+                            'v-bind:disabled' => 'dataHidden' %>
 
-        <%= l.text_field  :title,
-                          placeholder: 'Required - Paper Title ex: Regulation of the Neural Circuitry of Emotion',
-                          class: "form-control hidden paper-title input-sm",
-                          disabled: true %>
-        <div class="form-group">
+          <%= l.text_field  :title,
+                            placeholder: 'Required - Paper Title ex: Regulation of the Neural Circuitry of Emotion',
+                            class: "form-control paper-title input-sm",
+                            'v-bind:class' => '{ hidden: hideTitleField }',
+                            'v-bind:disabled' => 'hideTitleField' %>
           <%= f.submit "Submit",
-                class: "btn btn-primary btn-xs hidden",
-                id: 'add_locator_submit',
+                class: "btn btn-primary btn-xs",
                 disabled: !(list.accepts_public_contributions? || current_user_can_edit?(list)) %>
-          <%= link_to "cancel", '#', id: "cancel-add-locator", class: "hidden" %>
+          <%= link_to "cancel", '', '@click.prevent' => 'cancelAdd', 'v-bind:class' => '{ hidden: dataHidden }' %>
         </div>
       </div>
     <% end %>
   </div>
 <% end %>
 
-<div id="add-reference">{{ message }}</div>
-
 <% content_for(:page_app) do %>
   <script>
     addReference = new Vue({
       el: '#add-reference',
       data: {
-        message: 'Hello world!'
+        dataHidden: true,
+        locatorType: '',
+        locatorIdPlaceholder: 'URL, DOI, or Pubmed'
+      },
+      methods: {
+        addDoi: function() {
+          this.dataHidden = false;
+          this.locatorType = 'doi';
+          this.locatorIdPlaceholder = "10.1371/journal.pone.0001897"
+        },
+        addPubmed: function() {
+          this.dataHidden = false;
+          this.locatorType = 'pubmed';
+          this.locatorIdPlaceholder = "18365029"
+        },
+        addUrl: function() {
+          this.dataHidden = false;
+          this.locatorType = 'link';
+          this.locatorIdPlaceholder = "http://example.org/"
+        },
+        submitLocator: function() {
+          alert('hey')
+        },
+        cancelAdd: function() {
+          this.dataHidden = true;
+          this.locatorType = '';
+        }
+      },
+      computed: {
+        hideTitleField: function() {
+          return !(this.locatorType === 'link')
+        }
       }
     });
   </script>

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -6,9 +6,9 @@
         <%= l.hidden_field :type, 'v-bind:value' => 'locatorType' %>
         <i>
           Or add a paper by
-          <%= link_to "DOI", '', '@click.prevent': "addDoi" %>,
-          <%= link_to "Pubmed ID", '', '@click.prevent': "addPubmed" %>,
-          or <%= link_to "URL", '', '@click.prevent': "addUrl" %>
+          <%= link_to "DOI", '', '@click.prevent': "setLocatorType('doi')" %>,
+          <%= link_to "Pubmed ID", '', '@click.prevent': "setLocatorType('pubmed')" %>,
+          or <%= link_to "URL", '', '@click.prevent': "setLocatorType('link')" %>
         </i>
         <div class="form-group" v-bind:class='{ hidden: dataHidden }'>
           <%= l.text_field  :id,
@@ -33,40 +33,33 @@
 
 <% content_for(:page_app) do %>
   <script>
-    addReference = new Vue({
+    var addReferenceApp = new Vue({
       el: '#add-reference',
       data: {
-        dataHidden: true,
-        locatorType: '',
-        locatorIdPlaceholder: 'URL, DOI, or Pubmed'
+        locatorType: null,
+        placeholderFor: {
+          doi: "DOI ex: '10.1371/journal.pone.0001897'",
+          pubmed: "Pubmed ID ex: '18365029'",
+          link: "URL ex: http://journals.plos.org/plosone/article?id=example"
+        }
       },
       methods: {
-        addDoi: function() {
-          this.dataHidden = false;
-          this.locatorType = 'doi';
-          this.locatorIdPlaceholder = "DOI ex: '10.1371/journal.pone.0001897'"
-        },
-        addPubmed: function() {
-          this.dataHidden = false;
-          this.locatorType = 'pubmed';
-          this.locatorIdPlaceholder = "Pubmed ID ex: '18365029'"
-        },
-        addUrl: function() {
-          this.dataHidden = false;
-          this.locatorType = 'link';
-          this.locatorIdPlaceholder = "URL ex: http://journals.plos.org/plosone/article?id=example"
-        },
-        submitLocator: function() {
-          alert('hey')
+        setLocatorType: function(refType) {
+          this.locatorType = refType;
         },
         cancelAdd: function() {
-          this.dataHidden = true;
-          this.locatorType = '';
+          this.locatorType = null;
         }
       },
       computed: {
         hideTitleField: function() {
           return !(this.locatorType === 'link')
+        },
+        locatorIdPlaceholder: function() {
+          return this.placeholderFor[this.locatorType]
+        },
+        dataHidden: function() {
+          return !this.locatorType;
         }
       }
     });

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -44,17 +44,17 @@
         addDoi: function() {
           this.dataHidden = false;
           this.locatorType = 'doi';
-          this.locatorIdPlaceholder = "10.1371/journal.pone.0001897"
+          this.locatorIdPlaceholder = "DOI ex: '10.1371/journal.pone.0001897'"
         },
         addPubmed: function() {
           this.dataHidden = false;
           this.locatorType = 'pubmed';
-          this.locatorIdPlaceholder = "18365029"
+          this.locatorIdPlaceholder = "Pubmed ID ex: '18365029'"
         },
         addUrl: function() {
           this.dataHidden = false;
           this.locatorType = 'link';
-          this.locatorIdPlaceholder = "http://example.org/"
+          this.locatorIdPlaceholder = "URL ex: http://journals.plos.org/plosone/article?id=example"
         },
         submitLocator: function() {
           alert('hey')

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -30,3 +30,16 @@
     <% end %>
   </div>
 <% end %>
+
+<div id="add-reference">{{ message }}</div>
+
+<% content_for(:page_app) do %>
+  <script>
+    addReference = new Vue({
+      el: '#add-reference',
+      data: {
+        message: 'Hello world!'
+      }
+    });
+  </script>
+<% end %>

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -17,7 +17,7 @@
                             'v-bind:disabled' => 'dataHidden' %>
 
           <%= l.text_field  :title,
-                            placeholder: 'Required - Paper Title ex: Regulation of the Neural Circuitry of Emotion',
+                            placeholder: 'Required - Ex: Regulation of the Neural Circuitry of Emotion',
                             class: "form-control paper-title input-sm",
                             'v-bind:class' => '{ hidden: hideTitleField }',
                             'v-bind:disabled' => 'hideTitleField' %>
@@ -38,9 +38,9 @@
       data: {
         locatorType: null,
         placeholderFor: {
-          doi: "DOI ex: '10.1371/journal.pone.0001897'",
-          pubmed: "Pubmed ID ex: '18365029'",
-          link: "URL ex: http://journals.plos.org/plosone/article?id=example"
+          doi: "Ex: 10.1038/srep23344",
+          pubmed: "Ex: 18365029",
+          link: "Ex: http://example.org/article?id=1"
         }
       },
       methods: {


### PR DESCRIPTION
**Problem:** jQuery produces spaghetti code

**Solution:** Replace it with Vue.js

**Additional Notes:**

1. Considering that we use DOM manipulation in jQuery and binding in Vue.js, we might very well end up replacing jQuery with Vue entirely. This also fits with Rails 5.1, since they will be removing jQuery support - not that we need to follow 5.1. Loading both jQuery and Vue is kind of wasteful since they're both large requirements. Getting rid of jQuery means that we would have to switch to using plain Javascript, which we should probably do, anyway
1. I'm not using Vue components in this pull request. I'm actually using a very small subset of the Vue library. Part of this is the way that it works at the moment - this is not a single page app, it's just small Vue apps on a per-page basis. Unfortunately, in retrospect, many of the benefits of having a modern frontend go hand-in-hand with having a SPA - and a frontend router and all that jazz.
