### PR TITLE
mailchimp API call only in production

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,6 +36,12 @@
     },
     "GA_TRACKING_ID": {
       "required": true
+    },
+    "MAILCHIMP_API_KEY": {
+      "required": true
+    },
+    "ALLUSERS_LIST_ID": {
+      "required": true
     }
   },
   "formation": {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   private
 
   def subscribe_user_to_all_users_list
-    if Rails.env.production? && !ENV['IS_REVIEW_APP] %> 
+    if Rails.env.production? && !ENV['IS_REVIEW_APP'] %> 
       gb = Gibbon::Request.new
       gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   private
 
   def subscribe_user_to_all_users_list
-    if ENV['RAILS_ENV'] == 'production'
+    if ENV['RAILS_ENV'] == 'production' && ! ENV['IS_REVIEW_APP']
       gb = Gibbon::Request.new
       gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   private
 
   def subscribe_user_to_all_users_list
-    if Rails.env.production? && !ENV['IS_REVIEW_APP'] %> 
+    if Rails.env.production? && !ENV['IS_REVIEW_APP'] 
       gb = Gibbon::Request.new
       gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,8 +85,10 @@ class User < ApplicationRecord
   private
 
   def subscribe_user_to_all_users_list
-    gb = Gibbon::Request.new
-    gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
+    if ENV['RAILS_ENV'] == 'production'
+      gb = Gibbon::Request.new
+      gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
+    end
   end
 
   protected

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   private
 
   def subscribe_user_to_all_users_list
-    if ENV['RAILS_ENV'] == 'production' && ! ENV['IS_REVIEW_APP']
+    if Rails.env.production? && !ENV['IS_REVIEW_APP] %> 
       gb = Gibbon::Request.new
       gb.lists(ENV['ALLUSERS_LIST_ID']).members.create(body: {email_address: self.email, status: "subscribed", merge_fields: {USERNAME: self.username}})
     end


### PR DESCRIPTION
**Problem:**
Gibbon was adding emails to mailchimp and breaking heroku auto deployments
**Solution:**
Only make mailchimp API calls in production.


