### PR TITLE
Last update inclusive

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,6 +18,7 @@ class CommentsController < ApplicationController
         format.js do
           commentable = @comment.root.commentable
           is_top_level = !!@comment.commentable
+          commentable.touch
 
           if is_top_level
             render('commentables/comments/create.js.erb', locals: {commentable: commentable})
@@ -94,4 +95,5 @@ class CommentsController < ApplicationController
       return commentable if commentable.is_a?(List)
       return commentable.list if commentable.is_a?(Reference)
     end
+
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -2,7 +2,7 @@ class Reference < ApplicationRecord
   has_many :comments, as: :commentable
 
   belongs_to :paper
-  belongs_to :list
+  belongs_to :list, touch: true
   belongs_to :user
 
   validates :paper, uniqueness: { scope: :list }


### PR DESCRIPTION
**Problem:**
Last List update would only update based on list edits
**Solution:**
Use touch on reference and add touch on commentable in comment create
**Additional Notes:**
I don't know if we want to create another column instead of list.update_at if we want to track the last time the list specific items were updated.  I'm only including touches on references create/destroy and comments.  I added the touch to comments on the controller because if we had it on the comment model, it would only touch if a top level comment was created.  

Let me know what you think.


